### PR TITLE
Fix some destroy functions taking a very long time

### DIFF
--- a/flxanimate/animate/FlxLayer.hx
+++ b/flxanimate/animate/FlxLayer.hx
@@ -104,9 +104,9 @@ class FlxLayer extends FlxObject implements IFilterable
 		_filterFrame = FlxDestroyUtil.destroy(_filterFrame);
 		_filterCamera = FlxDestroyUtil.destroy(_filterCamera);
 		_filterMatrix = null;
-		FlxG.bitmap.remove(FlxG.bitmap.get(FlxG.bitmap.findKeyForBitmap(_bmp1)));
+		if (_bmp1 != null) FlxG.bitmap.remove(FlxG.bitmap.get(FlxG.bitmap.findKeyForBitmap(_bmp1)));
 		_bmp1 = FlxDestroyUtil.dispose(_bmp1);
-		FlxG.bitmap.remove(FlxG.bitmap.get(FlxG.bitmap.findKeyForBitmap(_bmp2)));
+		if (_bmp2 != null) FlxG.bitmap.remove(FlxG.bitmap.get(FlxG.bitmap.findKeyForBitmap(_bmp2)));
 		_bmp2 = FlxDestroyUtil.dispose(_bmp2);
 
 		for (keyframe in _keyframes)

--- a/flxanimate/animate/SymbolParameters.hx
+++ b/flxanimate/animate/SymbolParameters.hx
@@ -161,9 +161,9 @@ class SymbolParameters implements IFilterable
 		_filterFrame = FlxDestroyUtil.destroy(_filterFrame);
 		_filterCamera = FlxDestroyUtil.destroy(_filterCamera);
 		_filterMatrix = null;
-		FlxG.bitmap.remove(FlxG.bitmap.get(FlxG.bitmap.findKeyForBitmap(_bmp1)));
+		if (_bmp1 != null) FlxG.bitmap.remove(FlxG.bitmap.get(FlxG.bitmap.findKeyForBitmap(_bmp1)));
 		_bmp1 = FlxDestroyUtil.dispose(_bmp1);
-		FlxG.bitmap.remove(FlxG.bitmap.get(FlxG.bitmap.findKeyForBitmap(_bmp2)));
+		if (_bmp2 != null) FlxG.bitmap.remove(FlxG.bitmap.get(FlxG.bitmap.findKeyForBitmap(_bmp2)));
 		_bmp2 = FlxDestroyUtil.dispose(_bmp2);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/FunkinCrew/Funkin/issues/3178

If the bitmaps were null it would still attempt to search for them which would take forever depending on the cache's size.
(Note: I used this branch as base since it's the one Funkin currently uses)

Alternatively this could be merged instead: https://github.com/Dot-Stuff/flxanimate/pull/73