### PR TITLE
Fix for Freeplay DJ turntable lights

### DIFF
--- a/flxanimate/animate/FlxElement.hx
+++ b/flxanimate/animate/FlxElement.hx
@@ -96,10 +96,6 @@ class FlxElement extends FlxObject implements IFlxDestroyable
 				default: symbol.firstFrame;
 			}
 
-			if (symbol.type == MovieClip)
-				curFF = 0;
-
-
 			symbol.update(curFF);
 			@:privateAccess
 			if (symbol._renderDirty && _parent != null && _parent._cacheAsBitmap)


### PR DESCRIPTION
The glow is a MovieClip, which doesn't animate. There is some code that forced the symbol to the 1st frame if it was a MovieClip, which was removed in a later FlxAnimate commit that isn't in `funkin-dev`.

With this change, the turntable lights look a lot better now!!!
![image](https://github.com/user-attachments/assets/5d7d95c4-a9b5-4329-893e-c82973d69f9e)