### PR TITLE
[OPTIMIZATION?] Remove unused `Assets.list` call

### DIFF
--- a/flxanimate/frames/FlxAnimateFrames.hx
+++ b/flxanimate/frames/FlxAnimateFrames.hx
@@ -42,8 +42,6 @@ class FlxAnimateFrames extends FlxAtlasFrames
 	{
 		var frames:FlxAnimateFrames = new FlxAnimateFrames();
 
-		var texts = Assets.list(TEXT).filter((text) -> StringTools.startsWith(text, '$Path/sprite'));
-
 		var texts = [];
 		var isDone = false;
 


### PR DESCRIPTION
Should help with issues like https://github.com/FunkinCrew/Funkin/issues/5473, and https://github.com/FunkinCrew/Funkin/issues/5478 (which I think is a duplicate of the former?) until https://github.com/larsiusprime/polymod/issues/238 is fixed or `flixel-animate` is finally used.

> [!IMPORTANT]
> Abnormal's change will probably have to be reverted or else RIP mobile users :/